### PR TITLE
⬆️ Update checkout action from v5 to v6 in all workflows

### DIFF
--- a/.github/workflows/uv-tests.yml
+++ b/.github/workflows/uv-tests.yml
@@ -21,7 +21,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: pre-commit/action@v3.0.1
@@ -34,7 +34,7 @@ jobs:
       matrix:
         uv-version: ["0.7.3", "latest"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@v7

--- a/project_name/.github/workflows/ci.yml.jinja
+++ b/project_name/.github/workflows/ci.yml.jinja
@@ -24,7 +24,7 @@ jobs:
   format-python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       {%- if format_tool == "black" %}
@@ -41,7 +41,7 @@ jobs:
   ruff-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: astral-sh/ruff-action@v3
@@ -51,7 +51,7 @@ jobs:
       COLUMNS: 120
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: pre-commit/action@v3.0.1
@@ -59,7 +59,7 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@v7
@@ -80,7 +80,7 @@ jobs:
   dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@v7
@@ -127,7 +127,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: test-${{ matrix.python-version }}-${{ matrix.resolution }}-${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@v7
@@ -194,7 +194,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: test-${{ matrix.python-version }}-${{ matrix.resolution }}-${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@v7
@@ -232,7 +232,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@v7

--- a/project_name/.github/workflows/weekly-ci.yml.jinja
+++ b/project_name/.github/workflows/weekly-ci.yml.jinja
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@v7
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@v7

--- a/project_name/.github/workflows/{% if in_pypi %}build-and-publish.yml{% endif %}.jinja
+++ b/project_name/.github/workflows/{% if in_pypi %}build-and-publish.yml{% endif %}.jinja
@@ -30,7 +30,7 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: hynek/build-and-inspect-python-package@v2


### PR DESCRIPTION
Update actions/checkout from v5 to v6 across all GitHub workflow files in both the repository and template to use the latest version.

Files updated:
- .github/workflows/uv-tests.yml
- project_name/.github/workflows/ci.yml.jinja
- project_name/.github/workflows/weekly-ci.yml.jinja
- project_name/.github/workflows/build-and-publish.yml.jinja

## Summary by Sourcery

CI:
- Bump actions/checkout from v5 to v6 across all CI, test, and publish workflows, including the project template workflows.