### PR TITLE
Upgrade actions/download-artifact to v8

### DIFF
--- a/project_name/.github/workflows/{% if in_pypi %}build-and-publish.yml{% endif %}.jinja
+++ b/project_name/.github/workflows/{% if in_pypi %}build-and-publish.yml{% endif %}.jinja
@@ -48,7 +48,7 @@ jobs:
       id-token: write
     steps:
       - name: Download package distributions
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: Packages
           path: dist/
@@ -70,7 +70,7 @@ jobs:
       id-token: write
     steps:
       - name: Download package distributions
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: Packages
           path: dist/


### PR DESCRIPTION
## Summary
This PR upgrades the `actions/download-artifact` GitHub Action from v7 to v8 across the build and publish workflow.

## Changes
- Updated `actions/download-artifact` version from v7 to v8 in two workflow jobs:
  - PyPI publish job
  - Test PyPI publish job

## Details
The upgrade ensures the workflow uses the latest version of the download-artifact action, which may include bug fixes, performance improvements, and new features provided by the v8 release.

https://claude.ai/code/session_019L8y44hNUtmyRmSxyv7guY