### PR TITLE
Enable native parser for mypy type checking

### DIFF
--- a/project_name/pyproject.toml.jinja
+++ b/project_name/pyproject.toml.jinja
@@ -107,7 +107,7 @@ docs = [
   "mkdocs-section-index ~=0.3.0",
 ]
 typing = [
-  "mypy ~=1.19.0",
+  "mypy[native-parser] ~=1.19.0",
   "ty ~=0.0",
   # add "*-stubs" and "types-*" packages here (">=0")
 ]


### PR DESCRIPTION
## Summary
Updated the mypy dependency configuration to use the native parser implementation, which provides improved performance and reliability for type checking.

## Changes
- Modified `pyproject.toml.jinja` to add the `native-parser` extra to the mypy dependency specification
- Changed `mypy ~=1.19.0` to `mypy[native-parser] ~=1.19.0` in the typing dependencies group

## Details
The native parser is mypy's modern parser implementation that offers better performance characteristics compared to the default parser. This change ensures the project uses the optimized parsing backend for type checking operations.

https://claude.ai/code/session_01QXJXTFoz2DVZyGd2MDTGs3