### PR TITLE
Add zizmor security linter to pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -147,6 +147,10 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.23.1
+    hooks:
+      - id: zizmor
 
   # shell scripts
   - repo: https://github.com/shellcheck-py/shellcheck-py

--- a/project_name/.pre-commit-config.yaml.jinja
+++ b/project_name/.pre-commit-config.yaml.jinja
@@ -212,6 +212,10 @@ repos:
     rev: <placeholder_until_update_deps>
     hooks:
       - id: actionlint
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: <placeholder_until_update_deps>
+    hooks:
+      - id: zizmor
 
   # Shell scripts
   - repo: https://github.com/shellcheck-py/shellcheck-py


### PR DESCRIPTION
## Summary
This PR adds zizmor, a security linter for GitHub Actions workflows, to the pre-commit configuration.

## Changes
- Added zizmor pre-commit hook (v1.23.1) to `.pre-commit-config.yaml`
- Added zizmor pre-commit hook configuration to the project template `.pre-commit-config.yaml.jinja`

## Details
Zizmor is a security-focused linter for GitHub Actions workflows that helps identify potential security issues and misconfigurations. The hook is configured to run on all commits and will be automatically updated along with other dependencies during dependency updates.

https://claude.ai/code/session_011EyCivxz6Z1UJVsienHLQe