### PR TITLE
Upgrade mypy to 1.20.0

### DIFF
--- a/project_name/pyproject.toml.jinja
+++ b/project_name/pyproject.toml.jinja
@@ -107,7 +107,7 @@ docs = [
   "mkdocs-section-index ~=0.3.0",
 ]
 typing = [
-  "mypy[native-parser] ~=1.19.0",
+  "mypy[native-parser] ~=1.20.0",
   "ty ~=0.0",
   # add "*-stubs" and "types-*" packages here (">=0")
 ]
@@ -185,7 +185,7 @@ mypy_path = "stubs"
 fixed_format_cache = true
 # set the platform
 python_version = "3.{{ python_min }}"
-# enable checks [last updated: mypy 1.19]
+# enable checks [last updated: mypy 1.20]
 strict = true
 strict_equality_for_none = true
 local_partial_types = true


### PR DESCRIPTION
## Summary
This PR updates the mypy dependency and configuration to version 1.20.0.

## Changes
- Updated mypy dependency from `~=1.19.0` to `~=1.20.0` in the typing extras
- Updated the mypy configuration comment to reflect the latest version used (1.20)

## Details
The mypy configuration remains otherwise unchanged, with all strict mode checks continuing to be enabled. This is a routine dependency upgrade to leverage the latest improvements and bug fixes in mypy 1.20.0.

https://claude.ai/code/session_01NjZcMYMkvPC52ePoynXus8