### PR TITLE
Update GitHub Actions dependencies to latest versions

### DIFF
--- a/project_name/.github/workflows/ci.yml.jinja
+++ b/project_name/.github/workflows/ci.yml.jinja
@@ -28,12 +28,12 @@ jobs:
         with:
           persist-credentials: false
       {%- if format_tool == "black" %}
-      - uses: psf/black@35ea67920b7f6ac8e09be1c47278752b1e827f76 # stable
+      - uses: psf/black@c6755bb741b6481d6b3d3bb563c83fa060db96c9 # stable
         with:
           jupyter: {{ "true" if contains_jupyter_files else "false" }}
           use_pyproject: true
       {%- elif format_tool == "ruff" %}
-      - uses: astral-sh/ruff-action@146cd51f235777a9bc491eead18e0d5a4b05406a # v3
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
         with:
           args: format --check
       {%- endif %}
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: astral-sh/ruff-action@146cd51f235777a9bc491eead18e0d5a4b05406a # v3
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
 
   pre-commit:
     env:

--- a/project_name/.github/workflows/{% if in_pypi %}build-and-publish.yml{% endif %}.jinja
+++ b/project_name/.github/workflows/{% if in_pypi %}build-and-publish.yml{% endif %}.jinja
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: hynek/build-and-inspect-python-package@e6f4945c542cb46284a23bdb29121f4593636894 # v2
+      - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2
 
   publish-to-testpypi:
     if: github.event_name == 'push'


### PR DESCRIPTION
## Summary
This pull request updates the pinned versions of GitHub Actions used in the CI/CD workflows to their latest commits.

## Key Changes
- **black formatter**: Updated from `35ea67920b7f6ac8e09be1c47278752b1e827f76` to `c6755bb741b6481d6b3d3bb563c83fa060db96c9`
- **ruff-action**: Updated from `146cd51f235777a9bc491eead18e0d5a4b05406a` to `4919ec5cf1f49eff0871dbcea0da843445b837e6` (updated in 2 locations: format check and lint jobs)
- **build-and-inspect-python-package**: Updated from `e6f4945c542cb46284a23bdb29121f4593636894` to `fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e`

## Details
All version tags remain at their current major/minor versions (black: stable, ruff-action: v3, build-and-inspect-python-package: v2), ensuring compatibility while incorporating the latest bug fixes and improvements from each action's maintainers.

https://claude.ai/code/session_015PmZAbyXBkLPktTXGMx5BX