### PR TITLE
Add cache-suffix to setup-uv actions across CI workflows

### DIFF
--- a/project_name/.github/workflows/ci.yml.jinja
+++ b/project_name/.github/workflows/ci.yml.jinja
@@ -63,6 +63,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          cache-suffix: mypy
       - name: Install packages
         run: >-
           uv sync
@@ -84,6 +86,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          cache-suffix: deps
       - name: Install packages
         run: >-
           uv sync
@@ -237,6 +241,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          cache-suffix: pylint
       - name: Install packages
         run: >-
           uv sync

--- a/project_name/.github/workflows/deps-update.yml
+++ b/project_name/.github/workflows/deps-update.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          cache-suffix: deps-update
       - name: Sync dependencies
         run: uv sync
       - name: Update dependencies

--- a/project_name/.github/workflows/weekly-ci.yml.jinja
+++ b/project_name/.github/workflows/weekly-ci.yml.jinja
@@ -100,6 +100,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          cache-suffix: pip-audit
       - name: Export packages
         run: >-
           uv export


### PR DESCRIPTION
## Summary
This PR adds `cache-suffix` parameters to all `astral-sh/setup-uv` action invocations across the CI workflow files to enable job-specific caching strategies.

## Key Changes
- **ci.yml**: Added cache suffixes to three jobs:
  - `mypy` job: `cache-suffix: mypy`
  - `deps` job: `cache-suffix: deps`
  - `pylint` job: `cache-suffix: pylint`

- **deps-update.yml**: Added cache suffix to the dependency update job:
  - `cache-suffix: deps-update`

- **weekly-ci.yml**: Added cache suffix to the pip-audit job:
  - `cache-suffix: pip-audit`

## Implementation Details
Each `setup-uv` action now includes a `with:` block specifying a unique `cache-suffix` value that corresponds to the job's purpose. This allows GitHub Actions to maintain separate caches for each job type, preventing cache conflicts and improving cache hit rates by ensuring that job-specific dependencies are cached independently.

https://claude.ai/code/session_01No4QEgz6Vc6zXDYWNnnYGY