### PR TITLE
Upgrade ruff-action from v3 to v4.0.0

### DIFF
--- a/project_name/.github/workflows/ci.yml.jinja
+++ b/project_name/.github/workflows/ci.yml.jinja
@@ -33,7 +33,7 @@ jobs:
           jupyter: {{ "true" if contains_jupyter_files else "false" }}
           use_pyproject: true
       {%- elif format_tool == "ruff" %}
-      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
+      - uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
         with:
           args: format --check
       {%- endif %}
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
+      - uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
 
   pre-commit:
     env:


### PR DESCRIPTION
## Summary
Updates the `astral-sh/ruff-action` GitHub Action to version 4.0.0 across the CI workflow.

## Changes
- Updated ruff-action version from v3 (commit `4919ec5cf1f49eff0871dbcea0da843445b837e6`) to v4.0.0 (commit `0ce1b0bf8b818ef400413f810f8a11cdbda0034b`)
- Applied to both the format checking job and the linting job in the CI workflow

## Details
This upgrade brings the latest improvements and features from ruff v4.0.0, ensuring the project uses the most recent version of the ruff formatter and linter in its continuous integration pipeline.

https://claude.ai/code/session_014Koq3NLnrBL1rvvWa2REYr