### PR TITLE
Upgrade astral-sh/setup-uv action to v8.1.0

### DIFF
--- a/project_name/.github/workflows/ci.yml.jinja
+++ b/project_name/.github/workflows/ci.yml.jinja
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           cache-suffix: mypy
       - name: Install packages
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           cache-suffix: deps
       - name: Install packages
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: ${{ matrix.python-version }}
           cache-suffix: ${{ matrix.resolution }}
@@ -202,7 +202,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: ${{ matrix.python-version }}
           cache-suffix: ${{ matrix.resolution }}
@@ -240,7 +240,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           cache-suffix: pylint
       - name: Install packages

--- a/project_name/.github/workflows/weekly-ci.yml.jinja
+++ b/project_name/.github/workflows/weekly-ci.yml.jinja
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: '3.{{ python_max }}'
           enable-cache: false
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           cache-suffix: pip-audit
       - name: Export packages


### PR DESCRIPTION
## Summary
This pull request updates the `astral-sh/setup-uv` GitHub Action from v8.0.0 to v8.1.0 across all CI/CD workflows.

## Changes
- Updated `astral-sh/setup-uv` action reference from `cec208311dfd045dd5311c1add060b2062131d57` (v8.0.0) to `08807647e7069bb48b6ef5acd8ec9567f424441b` (v8.1.0) in:
  - `.github/workflows/ci.yml.jinja` (5 occurrences across mypy, deps, test, test-min, and pylint jobs)
  - `.github/workflows/weekly-ci.yml.jinja` (2 occurrences across nightly and pip-audit jobs)

## Details
This is a minor version bump of the setup-uv action that maintains compatibility with existing workflow configurations while incorporating improvements and bug fixes from the v8.1.0 release.

https://claude.ai/code/session_01FaH3pa4MWhidpWhihL1VYB