### PR TITLE
⬆️ Replace pre-commit with prek for hook management

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Sensible defaults for all included tools are provided.
   - Replaces Flake8, isort, pyupgrade, yesqa, pycln, and dozens of plugins
 - Static type checking with [MyPy](https://mypy-lang.org/)
 - Curated `.gitignore` file
-- Formatting and linting run automatically on commit via [pre-commit](https://pre-commit.com/) hooks:
+- Formatting and linting run automatically on commit via [pre-commit](https://pre-commit.com/) hooks, running with [prek](https://prek.j178.dev/):
   - [EditorConfig](https://editorconfig.org/) for consistent formatting across editors
   - Spell checking with [codespell](https://github.com/codespell-project/codespell) and [typos](https://github.com/crate-ci/typos)
   - Markdown formatting with [Mdformat](https://mdformat.readthedocs.io/)

--- a/project_name/.github/workflows/ci.yml.jinja
+++ b/project_name/.github/workflows/ci.yml.jinja
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
 
-  pre-commit:
+  prek:
     env:
       COLUMNS: 120
     runs-on: ubuntu-latest
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - uses: j178/prek-action@cbc2f23eb5539cf20d82d1aabd0d0ecbcc56f4e3 # v2
 
   mypy:
     runs-on: ubuntu-latest
@@ -272,7 +272,7 @@ jobs:
     needs:
       - format-python
       - ruff-check
-      - pre-commit
+      - prek
       - mypy
       - dependencies
       - test

--- a/project_name/CONTRIBUTING.md.jinja
+++ b/project_name/CONTRIBUTING.md.jinja
@@ -50,7 +50,7 @@ Ready to get started? Follow the development setup below.
 - **Lint code**: `uv run just lint` (runs all the linting tools)
 - **Format and lint code**: `uv run just quick-tools` (runs quick formatting and linting tools)
 - **Run tests**: `uv run just test` (runs `pytest`)
-- **Run pre-commit tests**: `uv run pre-commit run`. This also runs on each commit.
+- **Run pre-commit tests**: `uv run prek run`. This also runs on each commit.
 - **Run all checks**: `uv run just format lint test`
 
 ### Running Individual Tools
@@ -62,7 +62,7 @@ You can run specific tools directly:
 uv run ruff check
 uv run mypy
 uv run pytest
-uv run pre-commit run
+uv run prek run
 ```
 
 [how-to-contribute]: https://opensource.guide/how-to-contribute/

--- a/project_name/justfile.jinja
+++ b/project_name/justfile.jinja
@@ -37,7 +37,7 @@ deps-list-outdated:
 # Update all dependencies
 deps-update: && deps-list-outdated
   uv sync --upgrade
-  uv run prek autoupdate -j 0 | grep -v 'appears to be a mutable reference'
+  uv run prek auto-update -j 0 | grep -v 'appears to be a mutable reference'
   uvx sync-with-uv
   uvx sync-pre-commit-deps --yaml-mapping 2 --yaml-sequence 4 --yaml-offset 2 .pre-commit-config.yaml || { \
     echo "Note: '.pre-commit-config.yaml' changed, and might lost its formatting." \

--- a/project_name/justfile.jinja
+++ b/project_name/justfile.jinja
@@ -37,7 +37,7 @@ deps-list-outdated:
 # Update all dependencies
 deps-update: && deps-list-outdated
   uv sync --upgrade
-  uv run prek auto-update -j 0 | grep -v 'appears to be a mutable reference'
+  uv run prek auto-update
   uvx sync-with-uv
   uvx sync-pre-commit-deps --yaml-mapping 2 --yaml-sequence 4 --yaml-offset 2 .pre-commit-config.yaml || { \
     echo "Note: '.pre-commit-config.yaml' changed, and might lost its formatting." \

--- a/project_name/justfile.jinja
+++ b/project_name/justfile.jinja
@@ -25,7 +25,7 @@ init: && prepare
 
 # Setup the project after cloning
 prepare:
-  uv run pre-commit install --install-hooks
+  uv run prek install --install-hooks
 
 
 ### dependencies ###
@@ -37,7 +37,7 @@ deps-list-outdated:
 # Update all dependencies
 deps-update: && deps-list-outdated
   uv sync --upgrade
-  uv run pre-commit autoupdate -j 0 | grep -v 'appears to be a mutable reference'
+  uv run prek autoupdate -j 0 | grep -v 'appears to be a mutable reference'
   uvx sync-with-uv
   uvx sync-pre-commit-deps --yaml-mapping 2 --yaml-sequence 4 --yaml-offset 2 .pre-commit-config.yaml || { \
     echo "Note: '.pre-commit-config.yaml' changed, and might lost its formatting." \
@@ -82,10 +82,10 @@ format:
   {%- elif format_tool == "ruff" %}
   uv run ruff format
   {%- endif %}
-  uv run pre-commit run --all-files blacken-docs
-  uv run pre-commit run --all-files mdformat
+  uv run prek run --all-files blacken-docs
+  uv run prek run --all-files mdformat
   {%- if jupyter_files == "strip_outputs" %}
-  uv run pre-commit run --all-files nbstripout
+  uv run prek run --all-files nbstripout
   {%- endif %}
 
 # Run linters
@@ -93,7 +93,7 @@ lint:
   uv run ruff check
   uv run --exact --all-extras --no-default-groups --group typing --group test -- dmypy run
   uv run --exact --all-extras --all-groups --with deptry -- deptry src/
-  uv run --exact pre-commit run --all-files
+  uv run --exact prek run --all-files
 
 # Run Pylint (slow, not used in other tasks)
 pylint:

--- a/project_name/pyproject.toml.jinja
+++ b/project_name/pyproject.toml.jinja
@@ -71,7 +71,7 @@ dependencies = [
 dev = [
   ## used in the justfile
   "rust-just ~=1.0",
-  "pre-commit ~=4.0",
+  "prek ~=0.3.0",
   "black{% if contains_jupyter_files %}[jupyter]{% endif %} ~=26.1",
   "ruff ~=0.15.0",
   ## can be used for debug


### PR DESCRIPTION
## Summary

- Swap `pre-commit` for [`prek`](https://github.com/j178/prek), a Rust-based drop-in replacement, in dev deps and all `just` recipes.
- Use the canonical `prek auto-update` (hyphenated) command name; the old `autoupdate` alias still works but new flags (`--cooldown-days`, `--check`) are documented only on the hyphenated form.
- Replace `pre-commit/action` with `j178/prek-action@v2` (SHA-pinned) in CI.
- Drop the `-j` flag and the `appears to be a mutable reference` grep filter from `deps-update`: prek defaults `--jobs` to 0 (auto-detect cpu count) and does not emit the pre-commit-only warning the filter targeted.

## Test plan

- [ ] `just deps-update` succeeds and updates the rendered `.pre-commit-config.yaml`
- [ ] `just lint` passes locally with `prek run --all-files`
- [ ] CI `prek` job runs `prek run --all-files` and passes
- [ ] Initialize a fresh project from the template with `just init` and confirm `prek install --install-hooks` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)