### PR TITLE
Upgrade mypy to 2.1.0 and optimize type checking

### DIFF
--- a/project_name/.github/workflows/ci.yml.jinja
+++ b/project_name/.github/workflows/ci.yml.jinja
@@ -77,7 +77,7 @@ jobs:
       - name: List packages
         run: uv pip list
       - name: Run mypy
-        run: uv run --no-sync mypy --num-workers 4
+        run: uv run --no-sync mypy --num-workers "$(nproc)"
 
   dependencies:
     runs-on: ubuntu-latest

--- a/project_name/.github/workflows/ci.yml.jinja
+++ b/project_name/.github/workflows/ci.yml.jinja
@@ -77,7 +77,7 @@ jobs:
       - name: List packages
         run: uv pip list
       - name: Run mypy
-        run: uv run --no-sync mypy
+        run: uv run --no-sync mypy --num-workers 4
 
   dependencies:
     runs-on: ubuntu-latest

--- a/project_name/justfile.jinja
+++ b/project_name/justfile.jinja
@@ -91,7 +91,7 @@ format:
 # Run linters
 lint:
   uv run ruff check
-  uv run --exact --all-extras --no-default-groups --group typing --group test -- dmypy run
+  uv run --exact --all-extras --no-default-groups --group typing --group test -- dmypy run -- --num-workers 4
   uv run --exact --all-extras --all-groups --with deptry -- deptry src/
   uv run --exact pre-commit run --all-files
 

--- a/project_name/justfile.jinja
+++ b/project_name/justfile.jinja
@@ -91,7 +91,7 @@ format:
 # Run linters
 lint:
   uv run ruff check
-  uv run --exact --all-extras --no-default-groups --group typing --group test -- dmypy run -- --num-workers 4
+  uv run --exact --all-extras --no-default-groups --group typing --group test -- dmypy run
   uv run --exact --all-extras --all-groups --with deptry -- deptry src/
   uv run --exact pre-commit run --all-files
 

--- a/project_name/pyproject.toml.jinja
+++ b/project_name/pyproject.toml.jinja
@@ -107,7 +107,7 @@ docs = [
   "mkdocs-section-index ~=0.3.0",
 ]
 typing = [
-  "mypy[native-parser] ~=2.1.0",
+  "mypy ~=2.1.0",
   "ty ~=0.0",
   # add "*-stubs" and "types-*" packages here (">=0")
 ]

--- a/project_name/pyproject.toml.jinja
+++ b/project_name/pyproject.toml.jinja
@@ -107,7 +107,7 @@ docs = [
   "mkdocs-section-index ~=0.3.0",
 ]
 typing = [
-  "mypy[native-parser] ~=1.20.0",
+  "mypy[native-parser] ~=2.1.0",
   "ty ~=0.0",
   # add "*-stubs" and "types-*" packages here (">=0")
 ]
@@ -185,10 +185,9 @@ mypy_path = "stubs"
 fixed_format_cache = true
 # set the platform
 python_version = "3.{{ python_min }}"
-# enable checks [last updated: mypy 1.20]
+# enable checks [last updated: mypy 2.1]
 strict = true
 strict_equality_for_none = true
-local_partial_types = true
 disallow_any_unimported = true
 warn_unreachable = true
 disallow_any_explicit = true


### PR DESCRIPTION
## Summary
This PR upgrades mypy from version 1.20.0 to 2.1.0 and optimizes the type checking configuration and CI workflow.

## Key Changes
- **Dependency upgrade**: Updated mypy from `~=1.20.0` to `~=2.1.0` and removed the `[native-parser]` extra (no longer needed in 2.1.0)
- **Configuration update**: Removed `local_partial_types = true` from mypy config, which is no longer necessary with mypy 2.1.0
- **Performance optimization**: Added `--num-workers 4` flag to mypy invocation in CI to parallelize type checking across 4 workers
- **Documentation**: Updated mypy version reference in config comments from 1.20 to 2.1

## Implementation Details
The removal of `local_partial_types` configuration indicates that mypy 2.1.0 has improved its handling of partial types, making this explicit setting redundant. The parallel worker configuration in CI should reduce type checking time without requiring any code changes.

https://claude.ai/code/session_01DSZJX4JKn2or8vLdmoGECt