### PR TITLE
Simplify audit_in_ci help text in copier.yml

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -139,11 +139,8 @@ format_tool:
 audit_in_ci:
   type: bool
   help: >-
-    Run pip-audit in weekly CI? It audits the locked dependencies, which
-    only affect this repo's developers and CI -- downstream consumers
-    resolve their own deps, so the audit is mostly relevant for developer
-    safety. GitHub Dependabot alerts and `just deps-audit` are always
-    available.
+    Run pip-audit on locked deps in weekly CI? (Dependabot and
+    `just deps-audit` are always available.)
   default: false
 
 in_pypi:


### PR DESCRIPTION
## Summary
Simplified and clarified the help text for the `audit_in_ci` configuration option in copier.yml to be more concise while retaining the essential information.

## Changes
- Condensed the multi-line help text from 5 lines to 2 lines
- Removed redundant explanation about downstream consumers and dependency resolution
- Kept the core message: pip-audit runs on locked dependencies in weekly CI
- Maintained reference to alternative audit methods (Dependabot and `just deps-audit`)

## Details
The original help text was verbose and included context about how downstream consumers resolve their own dependencies. The updated version conveys the same essential information more concisely, making it easier to read while still explaining the purpose and available alternatives.

https://claude.ai/code/session_01QLH38Am27efEsDegHfk2Cg