### PR TITLE
Use `uv audit` for local deps-audit

### DIFF
--- a/.github/workflows/uv-tests.yml
+++ b/.github/workflows/uv-tests.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        uv-version: ["0.9.17", "latest"]
+        uv-version: ["0.10.12", "latest"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A modern Python project template using recommended development tools and best pr
 
 ## TL;DR
 
-Assuming that you have `uv` installed (version `>=0.9.17`)
+Assuming that you have `uv` installed (version `>=0.10.12`)
 
 1. `uvx copier copy gh:tsvikas/python-template path/to/project/directory/`
 

--- a/project_name/justfile.jinja
+++ b/project_name/justfile.jinja
@@ -46,10 +46,7 @@ deps-update: && deps-list-outdated
 
 # Audit dependencies
 deps-audit:
-  uv run --exact --all-extras --all-groups --with pip-audit -- \
-    pip-audit \
-    --skip-editable
-  uv run --exact true
+  uv audit --locked
 
 
 ### code quality ###

--- a/project_name/pyproject.toml.jinja
+++ b/project_name/pyproject.toml.jinja
@@ -114,7 +114,7 @@ typing = [
 
 
 [tool.uv]
-required-version = ">=0.9.17"
+required-version = ">=0.10.12"
 default-groups = ["dev", "test", "typing"]
 # Minimum age guard: only consider package versions released at least 24h ago,
 # as a lightweight supply-chain defense against just-published malicious releases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = ">=0.9.17"
+required-version = ">=0.10.12"
 # Minimum age guard: only consider package versions released at least 24h ago,
 # as a lightweight supply-chain defense against just-published malicious releases.
 exclude-newer = "24 hours"


### PR DESCRIPTION
## Summary

- Replace the `pip-audit`-via-`uv run` invocation in the `deps-audit` justfile recipe with `uv audit --locked` (faster, no extra install step).
- Bump the minimum uv version to `0.10.12` — first release where `uv audit` exits non-zero on findings (PR astral-sh/uv#18512) and appears in CLI help (PR astral-sh/uv#18540). Earlier versions can't reliably fail the recipe on vulnerabilities.
- Updates `pyproject.toml`, the template's `pyproject.toml.jinja`, the CI matrix in `uv-tests.yml`, and the README.

Note: `uv audit` is still a preview feature and emits an experimental warning. Pass `--preview-features audit` to silence it if desired.

## Test plan

- [ ] `uv-tests` CI matrix passes on both `0.10.12` and `latest`.
- [ ] Generated project runs `just deps-audit` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)