### PR TITLE
Update prek-action to latest commit

### DIFF
--- a/project_name/.github/workflows/ci.yml.jinja
+++ b/project_name/.github/workflows/ci.yml.jinja
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: j178/prek-action@cbc2f23eb5539cf20d82d1aabd0d0ecbcc56f4e3 # v2
+      - uses: j178/prek-action@6ad80277337ad479fe43bd70701c3f7f8aa74db3 # v2
 
   mypy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Updated the `j178/prek-action` GitHub Action to a newer commit version in the CI workflow.

## Changes
- Updated `j178/prek-action` from commit `cbc2f23eb5539cf20d82d1aabd0d0ecbcc56f4e3` to `6ad80277337ad479fe43bd70701c3f7f8aa74db3`
- The action version tag remains at `v2`

## Details
This update pulls in the latest changes from the prek-action repository while maintaining compatibility with the v2 release line.

https://claude.ai/code/session_012dRAy78W1Lcnmga2Y5iunB