### PR TITLE
Update hynek/build-and-inspect-python-package action

### DIFF
--- a/project_name/.github/workflows/{% if in_pypi %}build-and-publish.yml{% endif %}.jinja
+++ b/project_name/.github/workflows/{% if in_pypi %}build-and-publish.yml{% endif %}.jinja
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2
 
   publish-to-testpypi:
     if: github.event_name == 'push'


### PR DESCRIPTION
## Summary
Updates the `hynek/build-and-inspect-python-package` GitHub Action to a newer version.

## Changes
- Updated action pin from `fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e` to `d44ca7d91762de7a7d5436ddae667c6da6d1c3df` (both v2)

This update ensures the build and inspection workflow uses the latest improvements and fixes from the upstream action while maintaining compatibility with the v2 API.

https://claude.ai/code/session_01GoqAyvfs3ibciEi5Kd7che