### PR TITLE
Update prek-action to latest commit

### DIFF
--- a/project_name/.github/workflows/ci.yml.jinja
+++ b/project_name/.github/workflows/ci.yml.jinja
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: j178/prek-action@6ad80277337ad479fe43bd70701c3f7f8aa74db3 # v2
+      - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2
 
   mypy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Updated the `j178/prek-action` GitHub Action to a newer commit version while maintaining the same major version (v2).

## Changes
- Updated `j178/prek-action` action from commit `6ad80277337ad479fe43bd70701c3f7f8aa74db3` to `bdca6f102f98e2b4c7029491a53dfd366469e33d`
- This update applies to the CI workflow configuration

## Details
This is a routine dependency update for the GitHub Actions workflow. The action version tag remains at v2, but the underlying commit has been updated to incorporate any bug fixes or improvements released since the previous commit.

https://claude.ai/code/session_01UbUiFx1tDBqA4BDPUBhdy9