### PR TITLE
Bump black to 26.5.1 in pre-commit config and template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,14 +108,14 @@ repos:
 
   # python formatting and linting
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.3.1
+    rev: 26.5.1
     hooks:
       - id: black
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.20.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==26.3.1]
+        additional_dependencies: [black==26.5.1]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.11
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,7 +115,7 @@ repos:
     rev: 1.20.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==26.5.1]
+        additional_dependencies: [black==26.3.1]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.11
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,7 +115,7 @@ repos:
     rev: 1.20.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==26.3.1]
+        additional_dependencies: [black==26.5.1]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.11
     hooks:

--- a/project_name/.pre-commit-config.yaml.jinja
+++ b/project_name/.pre-commit-config.yaml.jinja
@@ -156,7 +156,7 @@ repos:
     rev: <placeholder_until_update_deps>
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==26.3.1]
+        additional_dependencies: [black==26.5.1]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: <placeholder_until_update_deps>
     hooks:


### PR DESCRIPTION
## Summary
- Bump the `black-pre-commit-mirror` hook rev from `26.3.1` to `26.5.1` in `.pre-commit-config.yaml`.
- Bump the `blacken-docs` hook's `additional_dependencies` from `black==26.3.1` to `black==26.5.1` in `.pre-commit-config.yaml`.
- Bump the same `blacken-docs` `additional_dependencies` pin to `black==26.5.1` in the template `project_name/.pre-commit-config.yaml.jinja`.

Both `black` and the `blacken-docs` black dependency must be bumped together, because the `sync-pre-commit-deps` hook (run by pre-commit.ci) syncs the `additional_dependencies` to the black hook's rev and will otherwise revert one of them.

## Test plan
- [ ] `pre-commit run --all-files` passes locally on the rendered project.
- [ ] pre-commit.ci on this PR does not auto-revert either version.

https://claude.ai/code/session_01FiZQCEunZaFRjUYWyYqSXK