### PR TITLE
Update Black code formatter to latest stable version

### DIFF
--- a/project_name/.github/workflows/ci.yml.jinja
+++ b/project_name/.github/workflows/ci.yml.jinja
@@ -28,7 +28,7 @@ jobs:
         with:
           persist-credentials: false
       {%- if format_tool == "black" %}
-      - uses: psf/black@c6755bb741b6481d6b3d3bb563c83fa060db96c9 # stable
+      - uses: psf/black@d2490e24dad33b8f68c77602ee29160de0fea24b # stable
         with:
           jupyter: {{ "true" if contains_jupyter_files else "false" }}
           use_pyproject: true


### PR DESCRIPTION
## Summary
Updated the Black code formatter GitHub Action to use the latest stable release.

## Changes
- Updated Black action from commit `c6755bb741b6481d6b3d3bb563c83fa060db96c9` to `d2490e24dad33b8f68c77602ee29160de0fea24b`
- This ensures the CI pipeline uses the most recent stable version of Black for Python code formatting

## Details
The Black formatter version is pinned to a specific commit hash while maintaining the `stable` tag reference. This update brings any improvements, bug fixes, and enhancements from the newer Black release to the project's continuous integration workflow.

https://claude.ai/code/session_01S5CRcz4poYUFgHBvbgMVJ7