### PR TITLE
Sync blacken-docs additional_dependencies from uv.lock

### DIFF
--- a/project_name/.pre-commit-config.yaml.jinja
+++ b/project_name/.pre-commit-config.yaml.jinja
@@ -156,7 +156,7 @@ repos:
     rev: <placeholder_until_update_deps>
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==26.5.1]
+        additional_dependencies: [black==<placeholder_until_update_deps>]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: <placeholder_until_update_deps>
     hooks:

--- a/project_name/justfile.jinja
+++ b/project_name/justfile.jinja
@@ -39,6 +39,7 @@ deps-update: && deps-list-outdated
   uv sync --upgrade
   uv run prek auto-update
   uvx sync-with-uv
+  just _sync-blacken-docs
   uvx sync-pre-commit-deps --yaml-mapping 2 --yaml-sequence 4 --yaml-offset 2 .pre-commit-config.yaml || { \
     echo "Note: '.pre-commit-config.yaml' changed, and might lost its formatting." \
     && exit 1; \
@@ -47,6 +48,13 @@ deps-update: && deps-list-outdated
 # Audit dependencies
 deps-audit:
   uv audit --locked
+
+# Sync blacken-docs' black additional_dependency with the version in uv.lock
+_sync-blacken-docs:
+  @black_ver=$(awk -F'"' '/^\[\[package\]\]/{p=0} /^name = "black"$/{p=1} p && /^version =/{print $2; exit}' uv.lock); \
+    if [ -n "$black_ver" ] && grep -q 'id: blacken-docs' .pre-commit-config.yaml; then \
+      sed -i -E "/id: blacken-docs/,/^  - repo:/ s/(black==)(<[^>]*>|[0-9][0-9a-z.+-]*)/\1$black_ver/" .pre-commit-config.yaml; \
+    fi
 
 
 ### code quality ###


### PR DESCRIPTION
## Summary
- Add a `_sync-blacken-docs` just recipe that reads the `black` version from `uv.lock` and rewrites `blacken-docs`' `additional_dependencies` in-place in `.pre-commit-config.yaml`, preserving file formatting (unlike `sync-pre-commit-deps`, which reformats).
- Wire it into `deps-update` before the existing `sync-pre-commit-deps` step. The latter is kept as a safety net for any other hooks that may carry `additional_dependencies` in the future.
- Replace the literal `black==26.5.1` pin in `project_name/.pre-commit-config.yaml.jinja` with `black==<placeholder_until_update_deps>`, matching the convention used for all `rev:` fields. The new recipe resolves it on first `deps-update`.

## Test plan
- [x] `just test` (ctt snapshot regeneration) passes locally
- [ ] Render the template with `format_tool=black` and confirm `deps-update` populates `additional_dependencies` to the same version as the `psf/black-pre-commit-mirror` rev
- [ ] Render the template with `format_tool=ruff` and confirm `deps-update` still resolves the placeholder (via `sync-pre-commit-deps` fallback, since `black` may not be in `uv.lock`)
- [ ] Confirm `.pre-commit-config.yaml` is not reformatted on the happy path (no spurious whitespace diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)