### PR TITLE
Upgrade minimum prek version to 0.4.0 in templates

### DIFF
--- a/project_name/pyproject.toml.jinja
+++ b/project_name/pyproject.toml.jinja
@@ -71,7 +71,7 @@ dependencies = [
 dev = [
   ## used in the justfile
   "rust-just ~=1.0",
-  "prek ~=0.3.0",
+  "prek ~=0.4.0",
   "black{% if contains_jupyter_files %}[jupyter]{% endif %} ~=26.1",
   "ruff ~=0.15.0",
   ## can be used for debug


### PR DESCRIPTION
## Summary
- Bump `prek` dev dependency pin in `project_name/pyproject.toml.jinja` from `~=0.3.0` to `~=0.4.0` (latest released line).

## Test plan
- [ ] CI / ctt snapshots
- [ ] Render template and confirm `uv sync` resolves prek 0.4.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)