### PR TITLE
Update GitHub Actions workflow dependencies to latest versions

### DIFF
--- a/project_name/.github/workflows/ci.yml.jinja
+++ b/project_name/.github/workflows/ci.yml.jinja
@@ -28,7 +28,7 @@ jobs:
         with:
           persist-credentials: false
       {%- if format_tool == "black" %}
-      - uses: psf/black@d2490e24dad33b8f68c77602ee29160de0fea24b # stable
+      - uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e # stable
         with:
           jupyter: {{ "true" if contains_jupyter_files else "false" }}
           use_pyproject: true
@@ -164,12 +164,12 @@ jobs:
           --junitxml=junit.xml
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && steps.run_tests.conclusion != 'skipped' }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}  # zizmor: ignore[secrets-outside-env]
           report_type: test_results
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}  # zizmor: ignore[secrets-outside-env]
     {%- endraw %}


### PR DESCRIPTION
## Summary
This PR updates pinned versions of GitHub Actions used in the CI workflow to their latest commits.

## Key Changes
- **psf/black**: Updated from `d2490e24dad33b8f68c77602ee29160de0fea24b` to `87928e6d6761a4a6d22250e1fee5601b3998086e` (stable)
- **codecov/codecov-action**: Updated from `57e3a136b779b570ffcdbf80b3bdc90e7fab3de2` to `e79a6962e0d4c0c17b229090214935d2e33f8354` (v6) in two locations:
  - Test results upload step
  - Coverage reports upload step

## Details
These updates ensure the CI workflow uses the latest stable versions of the code formatting and coverage reporting tools, bringing in any bug fixes and improvements from recent releases.

https://claude.ai/code/session_01Y4hJ9556E3hPkaSjoTXC7q