### PR TITLE
Relax CLI exit code assertion in test

### DIFF
--- a/project_name/tests/{% if cli_framework == 'typer' %}test_cli.py{% endif %}.jinja
+++ b/project_name/tests/{% if cli_framework == 'typer' %}test_cli.py{% endif %}.jinja
@@ -24,4 +24,4 @@ def test_app_version() -> None:
 
 def test_app_exit() -> None:
     result = runner.invoke(app, [])
-    assert result.exit_code == 2
+    assert result.exit_code != 0


### PR DESCRIPTION
## Summary
Updated the CLI exit code test to be more flexible by checking that the exit code is non-zero rather than asserting a specific value of 2.

## Changes
- Modified `test_app_exit()` to assert `result.exit_code != 0` instead of `result.exit_code == 2`

## Details
This change makes the test more robust by validating that the application exits with an error condition (any non-zero exit code) rather than being tightly coupled to a specific exit code value. This allows for greater flexibility in how the CLI framework handles errors while still ensuring the test catches unexpected successful exits.

https://claude.ai/code/session_01BM36AxKRGfX7iRcAr945PU